### PR TITLE
CMake updates for special MPI edge cases causes by Cray

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,6 @@ if (SYCL_RUNTIME)
         if (NOT ComputeCpp_DIR)
             message(FATAL_ERROR "ComputeCpp_DIR is undefined")
         endif ()
-
-#        get_filename_component(OpenCL_INCLUDE "include" ABSOLUTE)
-#        set(OpenCL_INCLUDE_DIR ${OpenCL_INCLUDE})
-
         add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
         set(COMPUTECPP_USER_FLAGS -O3 -fsycl-split-modules=20 -mllvm -inline-threshold=10000 -no-serial-memop)
         find_package(ComputeCpp REQUIRED)
@@ -45,8 +41,31 @@ else ()
 endif ()
 
 
-find_package(MPI REQUIRED)
-include_directories(SYSTEM ${MPI_INCLUDE_PATH})
+if (MPI_AS_LIBRARY)
+
+    if (NOT DEFINED MPI_C_LIB_DIR)
+        message(FATAL_ERROR "MPI_C_LIB_DIR must be specified, typically <mpi_root_dir>/lib")
+    endif ()
+
+    if (NOT DEFINED MPI_C_INCLUDE_DIR)
+        message(FATAL_ERROR "MPI_C_INCLUDE_DIR must be specified, typically <mpi_root_dir>/include")
+    endif ()
+
+    if (NOT DEFINED MPI_C_LIB)
+        message(FATAL_ERROR "MPI_C_LIB must be specified, for example: mpich for libmpich.so in MPI_C_LIB_DIR")
+    endif ()
+
+    message(STATUS "Using MPI as a library (${MPI_C_LIB})")
+    message(STATUS "MPI include dir: ${MPI_C_INCLUDE_DIR}")
+    message(STATUS "MPI library dir: ${MPI_C_LIB_DIR}")
+
+    include_directories(${MPI_C_INCLUDE_DIR})
+    link_directories(${MPI_C_LIB_DIR})
+else ()
+    find_package(MPI REQUIRED)
+    set(MPI_C_LIB MPI::MPI_C)
+endif ()
+
 
 set(SOURCES
         src/accelerate.cpp
@@ -96,14 +115,16 @@ target_compile_options(clover_leaf
         ${EXTRA_FLAGS}
         )
 
-set(DEBUG_OPTIONS -O2 -fno-omit-frame-pointer -march=native -g)
-set(RELEASE_OPTIONS -O3 -march=native -mtune=native)
+set(DEBUG_OPTIONS -O2 -fno-omit-frame-pointer ${CXX_EXTRA_FLAGS})
+set(RELEASE_OPTIONS -O3 ${CXX_EXTRA_FLAGS})
 
-target_link_libraries(clover_leaf PRIVATE ${MPI_CXX_LIBRARIES})
+target_link_libraries(clover_leaf PUBLIC ${MPI_C_LIB})
 
 target_compile_options(clover_leaf PUBLIC "$<$<CONFIG:RelWithDebInfo>:${RELEASE_OPTIONS}>")
 target_compile_options(clover_leaf PUBLIC "$<$<CONFIG:Release>:${RELEASE_OPTIONS}>")
 target_compile_options(clover_leaf PUBLIC "$<$<CONFIG:Debug>:${DEBUG_OPTIONS}>")
+
+target_link_options(clover_leaf PUBLIC LINKER:${CXX_EXTRA_LINKER_FLAGS})
 
 if (NOT ${SYCL_RUNTIME} STREQUAL "DPCPP")
     add_sycl_to_target(

--- a/README.md
+++ b/README.md
@@ -61,22 +61,26 @@ First, generate a build:
     
 Flags: 
  * `SYCL_RUNTIME` - one of `HIPSYCL|COMPUTECPP|DPCPP`
- * For `SYCL_RUNTIME=HIPSYCL`, supply hipSYCL install path with `HIPSYCL_INSTALL_DIR`
- * For `SYCL_RUNTIME=COMPUTECPP`, supply ComputeCpp install path with `ComputeCpp_DIR`
- * For `SYCL_RUNTIME=DPCPP`, make sure the DPC++ compiler (dpcpp) is available in `PATH` 
+   * For `SYCL_RUNTIME=HIPSYCL`, supply hipSYCL install path with `HIPSYCL_INSTALL_DIR`
+   * For `SYCL_RUNTIME=COMPUTECPP`, supply ComputeCpp install path with `ComputeCpp_DIR`
+   * For `SYCL_RUNTIME=DPCPP`, make sure the DPC++ compiler (dpcpp) is available in `PATH`
+ * `MPI_AS_LIBRARY` - `BOOL(ON|OFF)`, enable if CMake is unable to detect the correct MPI implementation or if you want to use a specific MPI installation. Use this a last resort only as your MPI implementation may pass on extra linker flags.
+   * Set `MPI_C_LIB_DIR` to  <mpi_root_dir>/lib
+   * Set `MPI_C_INCLUDE_DIR` to  <mpi_root_dir>/include
+   * Set `MPI_C_LIB` to the library name, for exampe: mpich for libmpich.so
+ * `CXX_EXTRA_FLAGS` - `STRING`, appends extra flags that will be passed on to the compiler, applies to all configs
+  * `CXX_EXTRA_LINKER_FLAGS` - `STRING`, appends extra linker flags (the comma separated list after the `-Wl` flag) to the linker, applies to all configs
     
 
 If parts of your toolchain are installed at different places, you'll have to specify it manually, for example:
 
     cmake3 -Bbuild -H.  \
-    -DOpenCL_INCLUDE_DIR=include/ \
-    -DOpenCL_LIBRARY=/nfs/software/x86_64/intel/opencl/18.1/opt/intel/opencl_compilers_and_libraries_18.1.0.015/linux/compiler/lib/intel64_lin/libOpenCL.so.2.0 \ 
     -DSYCL_RUNTIME=COMPUTECPP \
     -DComputeCpp_DIR=/nfs/software/x86_64/computecpp/1.1.3 \
     -DCMAKE_C_COMPILER=/nfs/software/x86_64/gcc/9.1.0/bin/gcc \
     -DCMAKE_CXX_COMPILER=/nfs/software/x86_64/gcc/9.1.0/bin/g++ \
     -DCMAKE_BUILD_TYPE=Release \
-
+    
 For ComputeCpp's experimental NVidia ptx support, add:
 
     -DCOMPUTECPP_BITCODE=ptx64


### PR DESCRIPTION
 * Added support for linking MPI as a plain C library
 * Added support for directly appending -Wl flags